### PR TITLE
fix version compatibility problem

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,9 @@ version: '3'
 
 services:
   source_postgres:
-    image: postgres:latest
+    image: postgres:15
     ports:
-      - "5433:5432"
+      - '5433:5432'
     networks:
       - elt_network
     environment:
@@ -15,9 +15,9 @@ services:
       - ./source_db_init/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   destination_postgres:
-    image: postgres:latest
+    image: postgres:15
     ports:
-      - "5434:5432"
+      - '5434:5432'
     networks:
       - elt_network
     environment:
@@ -29,7 +29,7 @@ services:
     build:
       context: ./elt_script # Directory containing the Dockerfile and elt_script.py
       dockerfile: Dockerfile # Name of the Dockerfile, if it's something other than "Dockerfile", specify here
-    command: [ "python", "elt_script.py" ]
+    command: ['python', 'elt_script.py']
     networks:
       - elt_network
     depends_on:

--- a/elt_script/Dockerfile
+++ b/elt_script/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 # Install PostgreSQL command-line tools
-RUN apt-get update && apt-get install -y postgresql-client
+RUN apt-get update && apt-get install -y postgresql-client-15
 
 # Copy the ELT script 
 COPY elt_script.py .


### PR DESCRIPTION
Hello, I’m so much thankful to your data engineering lecture, really! I found a small bug in your sample elt project,

As new postgres v16 come up, there’s an compatibility error while docker compose up.

![image](https://github.com/justinbchau/custom-elt-project/assets/25452313/28880914-a184-44b3-a8ff-281067bf9f21)

it says “pg_dump: error: aborting because of server version mismatch”, “pg_dump: detail: server version: 16.2 (Debian 16.2-1.pgdg120+2); pg_dump version: 15.6 (Debian 15.6-0+deb12u1)”.

I think It is better to define specific version (maybe 15) because newcomers don’t know the why problem happens and how to solve the problem.

If you accept the PR, then it works well as intended!

![image](https://github.com/justinbchau/custom-elt-project/assets/25452313/6b7c9aa3-0f4e-4c74-9a4a-9803a8665c5b)

Thank you!