### PR TITLE
fix mismatch pdump version issue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   source_postgres:
-    image: postgres:latest
+    image: postgres:16.2
     ports:
       - "5433:5432"
     networks:
@@ -15,7 +15,7 @@ services:
       - ./source_db_init/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   destination_postgres:
-    image: postgres:latest
+    image: postgres:16.2
     ports:
       - "5434:5432"
     networks:

--- a/elt_script/Dockerfile
+++ b/elt_script/Dockerfile
@@ -1,7 +1,14 @@
 FROM python:3.8-slim
 
-# Install PostgreSQL command-line tools
-RUN apt-get update && apt-get install -y postgresql-client
+# Install the dependencies for the PostgreSQL repository
+RUN apt-get update && apt-get install -y wget gnupg
+
+# Add the PostgreSQL repository to get the latest PostgreSQL client
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(. /etc/os-release; echo $VERSION_CODENAME)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Install PostgreSQL client version 16
+RUN apt-get update && apt-get install -y postgresql-client-16
 
 # Copy the ELT script 
 COPY elt_script.py .


### PR DESCRIPTION
Thanks for amazing tutorial:
This fixes the mismatch issue: `pg_dump: error: aborting because of server version mismatch` 
This is how the output looks like now:
<img width="1203" alt="Screenshot 2024-04-23 at 00 08 40" src="https://github.com/justinbchau/custom-elt-project/assets/13749603/dd68c504-4aea-47c1-bced-812a2358cb4b">
