### PR TITLE
fix missing 'opt' folder issue

### DIFF
--- a/airflow/dags/elt_dag.py
+++ b/airflow/dags/elt_dag.py
@@ -48,7 +48,7 @@ t2 = DockerOperator(
         "--profiles-dir",
         "/root",
         "--project-dir",
-        "/dbt",
+        "/opt/dbt",
         "--full-refresh"
     ],
     auto_remove=True,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,7 +117,7 @@ services:
     volumes:
       - ./airflow/dags:/opt/airflow/dags
       - ./elt_script:/opt/airflow/elt_script
-      - ./postgres_transformations:/dbt
+      - ./postgres_transformations:/opt/dbt
       - ~/.dbt:/root/.dbt
       - /var/run/docker.sock:/var/run/docker.sock
     environment:


### PR DESCRIPTION
So, i think in airflow part, we missed the `/opt` folder before /dbt in scheduler (presented in `webserver` part though)

without it, we would get this in Airflow Web UI on `dbt_run` task:

![image](https://github.com/user-attachments/assets/86d05b07-88da-46eb-b1da-23b4bb127c8a)


